### PR TITLE
Update scripts.js

### DIFF
--- a/src/page/scripts.js
+++ b/src/page/scripts.js
@@ -38,8 +38,16 @@ function goToApiDocs() {
 function goToFrontend() {
   window.location.href = "https://kapustaapp.vercel.app/";
 }
-
 window.onload = () => {
+const apiDocsButton = 
+document.getElementById('goToApiDocs')
+if(apiDocsButton) {apiDocsButton.addEventListener('click',goToApiDocs);}
+                 
+
+const frontendButton = 
+document.getElementById('goToFrontend')
+if(frontendButton){apiDocsButton.addEventListener('click',goToFrontend);}
+                  
   addRandomCabbages();
   setInterval(rotateAllCabbages, 3000);
 };


### PR DESCRIPTION
dotyczy bledu
Content-Security-Policy: The page’s settings blocked an event handler (script-src-attr) from being executed because it violates the following directive: “script-src-attr 'none'”
Source: goToFrontend()